### PR TITLE
Switch back to Caffe engine when freeze BN

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -167,16 +167,25 @@ shared_ptr<Layer<Dtype> > GetBNLayer(const LayerParameter& param) {
   BNParameter_Engine engine = param.bn_param().engine();
   if (engine == BNParameter_Engine_DEFAULT) {
     engine = BNParameter_Engine_CAFFE;
-#if defined(USE_CUDNN) 
+#if defined(USE_CUDNN)
 #if CUDNN_VERSION_MIN(4, 0, 0)
     engine = BNParameter_Engine_CUDNN;
 #endif
 #endif
   }
+#if defined(USE_CUDNN)
+#if CUDNN_VERSION_MIN(4, 0, 0)
+  if (engine == BNParameter_Engine_CUDNN && param.bn_param().frozen()) {
+    LOG(WARNING) << "Layer " << param.name() << " switches back to CAFFE engine"
+                 << " as CUDNN engine doesn't support frozen.";
+    engine = BNParameter_Engine_CAFFE;
+  }
+#endif
+#endif
   if (engine == BNParameter_Engine_CAFFE) {
     LOG(INFO) << "Layer " << param.name() << " is using CAFFE engine.";
     return shared_ptr<Layer<Dtype> >(new BNLayer<Dtype>(param));
-#if defined(USE_CUDNN) 
+#if defined(USE_CUDNN)
 #if CUDNN_VERSION_MIN(4, 0, 0)
   } else if (engine == BNParameter_Engine_CUDNN) {
     LOG(INFO) << "Layer " << param.name() << " is using CUDNN engine.";

--- a/src/caffe/layers/cudnn_bn_layer.cu
+++ b/src/caffe/layers/cudnn_bn_layer.cu
@@ -21,7 +21,7 @@ void CuDNNBNLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   const Dtype* scale_data = this->blobs_[0]->gpu_data();
   const Dtype* bias_data = this->blobs_[1]->gpu_data();
 
-  if (this->frozen_ || this->phase_ == TEST) {
+  if (this->phase_ == TEST) {
     const Dtype* running_mean_data = this->blobs_[2]->gpu_data();
     const Dtype* running_inv_variance_data = this->blobs_[3]->gpu_data();
     CUDNN_CHECK(cudnnBatchNormalizationForwardInference(handle_,
@@ -63,13 +63,8 @@ void CuDNNBNLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const Dtype* scale_data = this->blobs_[0]->gpu_data();
     Dtype* scale_diff = scale_buf_.mutable_gpu_diff();
     Dtype* bias_diff = bias_buf_.mutable_gpu_diff();
-
-    const Dtype* save_mean_data = NULL;
-    const Dtype* save_inv_variance_data = NULL;
-    if (!this->frozen_) {
-      save_mean_data = save_mean_.gpu_data();
-      save_inv_variance_data = save_inv_variance_.gpu_data();
-    }
+    const Dtype* save_mean_data = save_mean_.gpu_data();
+    const Dtype* save_inv_variance_data = save_inv_variance_.gpu_data();
 
     CUDNN_CHECK(cudnnBatchNormalizationBackward(handle_,
         CUDNN_BATCHNORM_SPATIAL,
@@ -83,15 +78,13 @@ void CuDNNBNLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         this->bn_eps_,
         save_mean_data, save_inv_variance_data));
 
-    if (!this->frozen_) {
-      if (this->param_propagate_down_[0]) {
-        caffe_gpu_add(scale_buf_.count(), scale_diff,
-            this->blobs_[0]->gpu_diff(), this->blobs_[0]->mutable_gpu_diff());
-      }
-      if (this->param_propagate_down_[1]) {
-        caffe_gpu_add(bias_buf_.count(), bias_diff,
-            this->blobs_[1]->gpu_diff(), this->blobs_[1]->mutable_gpu_diff());
-      }
+    if (this->param_propagate_down_[0]) {
+      caffe_gpu_add(scale_buf_.count(), scale_diff,
+          this->blobs_[0]->gpu_diff(), this->blobs_[0]->mutable_gpu_diff());
+    }
+    if (this->param_propagate_down_[1]) {
+      caffe_gpu_add(bias_buf_.count(), bias_diff,
+          this->blobs_[1]->gpu_diff(), this->blobs_[1]->mutable_gpu_diff());
     }
   }
 }


### PR DESCRIPTION
As Cudnn doesn't provide implementation for freezing BN layer parameters, we need to switch back to Caffe engine in this case.
