### PR TITLE
Improve the python interface

### DIFF
--- a/python/bn_convert_style.py
+++ b/python/bn_convert_style.py
@@ -4,6 +4,9 @@ import os
 import os.path as osp
 from argparse import ArgumentParser
 
+pycaffe_dir = osp.dirname(__file__)
+if osp.join(pycaffe_dir) not in sys.path:
+    sys.path.insert(0, pycaffe_dir)
 import caffe
 
 
@@ -15,26 +18,32 @@ def main(args):
         if name.endswith('_bn'):
             if conversion == 'var_to_inv_std':
                 var = param[3].data
-                inv_std = 1. / np.sqrt(var + eps)
+                inv_std = np.power(var + eps, -0.5)
                 param[3].data[...] = inv_std
             elif conversion == 'inv_std_to_var':
                 inv_std = param[3].data
                 var = np.power(inv_std, -2) - eps
                 param[3].data[...] = var
             else:
-                raise ValueError("Unknown conversion type {}".format(conversion))
+                raise ValueError("Unknown conversion {}".format(conversion))
+    if args.output is None:
+        name, ext = osp.splitext(args.weights)
+        suffix = conversion.split('_to_')[-1]
+        args.output = name + '_' + suffix + ext
     net.save(args.output)
 
 
 if __name__ == '__main__':
     parser = ArgumentParser(
         description="This script converts between two styles of BN models. "
-                    "Specifically, in history we have two version of BN implementation, one storing running variance"
+                    "Specifically, in history we have two versions of BN "
+                    "implementation---one storing running variance, and"
                     "the other storing running inverse std.")
     parser.add_argument('model', help="The deploy prototxt")
     parser.add_argument('weights', help="The caffemodel")
     parser.add_argument('--output', '-o', help="Output caffemodel")
     parser.add_argument('--conversion', type=str, default="inv_std_to_var",
+                        choices=['inv_std_to_var', 'var_to_inv_std'],
                         help='can be "var_to_inv_std" or "inv_std_to_var"')
     parser.add_argument('--epsilon', type=float, default=1e-5,
                         help='the epsilon in the inverse, default to 1e-5')

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -24,6 +24,19 @@
 #define PyArray_SetBaseObject(arr, x) (PyArray_BASE(arr) = (x))
 #endif
 
+/* Fix to avoid registration warnings in pycaffe (#3960) */
+#define BP_REGISTER_SHARED_PTR_TO_PYTHON(PTR) do { \
+  const boost::python::type_info info = \
+    boost::python::type_id<shared_ptr<PTR > >(); \
+  const boost::python::converter::registration* reg = \
+    boost::python::converter::registry::query(info); \
+  if (reg == NULL) { \
+    bp::register_ptr_to_python<shared_ptr<PTR > >(); \
+  } else if ((*reg).m_to_python == NULL) { \
+    bp::register_ptr_to_python<shared_ptr<PTR > >(); \
+  } \
+} while (0)
+
 namespace bp = boost::python;
 
 namespace caffe {
@@ -227,6 +240,7 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
     .def("save", &Net_Save);
+  BP_REGISTER_SHARED_PTR_TO_PYTHON(Net<Dtype>);
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)
@@ -241,6 +255,7 @@ BOOST_PYTHON_MODULE(_caffe) {
           NdarrayCallPolicies()))
     .add_property("diff",     bp::make_function(&Blob<Dtype>::mutable_cpu_diff,
           NdarrayCallPolicies()));
+  BP_REGISTER_SHARED_PTR_TO_PYTHON(Blob<Dtype>);
 
   bp::class_<Layer<Dtype>, shared_ptr<PythonLayer<Dtype> >,
     boost::noncopyable>("Layer", bp::init<const LayerParameter&>())
@@ -249,7 +264,7 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("setup", &Layer<Dtype>::LayerSetUp)
     .def("reshape", &Layer<Dtype>::Reshape)
     .add_property("type", bp::make_function(&Layer<Dtype>::type));
-  bp::register_ptr_to_python<shared_ptr<Layer<Dtype> > >();
+  BP_REGISTER_SHARED_PTR_TO_PYTHON(Layer<Dtype>);
 
   bp::class_<LayerParameter>("LayerParameter", bp::no_init);
 
@@ -263,6 +278,7 @@ BOOST_PYTHON_MODULE(_caffe) {
           &Solver<Dtype>::Solve), SolveOverloads())
     .def("step", &Solver<Dtype>::Step)
     .def("restore", &Solver<Dtype>::Restore);
+  BP_REGISTER_SHARED_PTR_TO_PYTHON(Solver<Dtype>);
 
   bp::class_<SGDSolver<Dtype>, bp::bases<Solver<Dtype> >,
     shared_ptr<SGDSolver<Dtype> >, boost::noncopyable>(

--- a/python/convert_to_fully_conv.py
+++ b/python/convert_to_fully_conv.py
@@ -1,0 +1,84 @@
+import numpy as np
+import os
+import os.path as osp
+import sys
+import google.protobuf as pb
+from argparse import ArgumentParser
+
+pycaffe_dir = osp.dirname(__file__)
+if osp.join(pycaffe_dir) not in sys.path:
+    sys.path.insert(0, pycaffe_dir)
+import caffe
+from caffe.proto import caffe_pb2
+
+
+def main(args):
+    caffe.set_mode_cpu()
+    fc_net = caffe.Net(args.model, args.weights, caffe.TEST)
+    # make fully conv prototxt
+    fc_proto = caffe_pb2.NetParameter()
+    with open(args.model, 'r') as f:
+        pb.text_format.Parse(f.read(), fc_proto)
+    layers = []
+    fc_to_conv_dic = {}
+    for layer in fc_proto.layer:
+        if layer.type != 'InnerProduct':
+            layers.append(layer)
+            continue
+        new_ = caffe_pb2.LayerParameter()
+        new_.name = layer.name + '_conv'
+        fc_to_conv_dic[layer.name] = new_.name
+        new_.type = 'Convolution'
+        new_.bottom.extend(layer.bottom)
+        new_.top.extend(layer.top)
+        new_.convolution_param.num_output = layer.inner_product_param.num_output
+        bottom_shape = fc_net.blobs[layer.bottom[0]].data.shape
+        if len(bottom_shape) == 4:
+            new_.convolution_param.kernel_h = bottom_shape[2]
+            new_.convolution_param.kernel_w = bottom_shape[3]
+        else:
+            new_.convolution_param.kernel_size = 1
+        layers.append(new_)
+    conv_proto = caffe_pb2.NetParameter()
+    conv_proto.CopyFrom(fc_proto)
+    del(conv_proto.layer[:])
+    conv_proto.layer.extend(layers)
+    if args.save_model is None:
+        name, ext = osp.splitext(args.model)
+        args.save_model = name + '_fully_conv' + ext
+    with open(args.save_model, 'w') as f:
+        f.write(pb.text_format.MessageToString(conv_proto))
+    # make fully conv parameters
+    conv_net = caffe.Net(args.save_model, args.weights, caffe.TEST)
+    for fc, conv in fc_to_conv_dic.iteritems():
+        conv_net.params[conv][0].data.flat = fc_net.params[fc][0].data.flat
+        conv_net.params[conv][1].data[...] = fc_net.params[fc][1].data
+    if args.save_weights is None:
+        name, ext = osp.splitext(args.weights)
+        args.save_weights = name + '_fully_conv' + ext
+    conv_net.save(args.save_weights)
+    print args.model, args.weights
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description="Convert fully connected layers to convolution layers"
+    )
+    parser.add_argument(
+        'model',
+        help="Path to input deploy prototxt"
+    )
+    parser.add_argument(
+        'weights',
+        help="Path to input caffemodel"
+    )
+    parser.add_argument(
+        '--save_model',
+        help="Path to output deploy prototxt"
+    )
+    parser.add_argument(
+        '--save_weights',
+        help="Path to output caffemodel"
+    )
+    args = parser.parse_args()
+    main(args)

--- a/python/polyak_average.py
+++ b/python/polyak_average.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""
+Example usage: To average caffenet_iter_10000.caffemodel,
+caffenet_iter_20000.caffemodel, and caffenet_iter_30000.caffemodel. Use command
+
+python2 polyak_average.py caffenet_deploy.prototxt caffenet_polyak.caffemodel \
+  --weight_prefix caffenet --iter_range "(10000,30001,10000)"
+"""
+import numpy as np
+import os.path as osp
+import sys
+from argparse import ArgumentParser
+
+pycaffe_dir = osp.dirname(__file__)
+if osp.join(pycaffe_dir) not in sys.path:
+    sys.path.insert(0, pycaffe_dir)
+import caffe
+
+
+def main(args):
+    if args.weight_files is not None:
+        weight_files = args.weight_files
+    else:
+        weight_files = [args.weight_prefix + '_iter_{}.caffemodel'.format(it)
+                        for it in args.iter_range]
+    assert len(weight_files) > 0, "Must have at least one caffemodel"
+    net = caffe.Net(args.model, weight_files[0], caffe.TEST)
+    count = {param_name: 1 for param_name in net.params.keys()}
+    for weight_file in weight_files[1:]:
+        tmp = caffe.Net(args.model, weight_file, caffe.TEST)
+        for param_name in np.intersect1d(net.params.keys(), tmp.params.keys()):
+            count[param_name] += 1
+            for w, v in zip(net.params[param_name], tmp.params[param_name]):
+                w.data[...] += v.data
+    for param_name in net.params:
+        if count[param_name] <= 1: continue
+        for w in net.params[param_name]:
+            w.data[...] /= count[param_name]
+    net.save(args.output)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('model', help="Net definition prototxt")
+    parser.add_argument('output', help="Path for saving the output")
+    parser.add_argument('--weight_files', type=str, nargs='+',
+        help="A list of caffemodels")
+    parser.add_argument('--weight_prefix', help="Prefix of caffemodels")
+    parser.add_argument('--iter_range',
+        help="Iteration range complementary with the prefix. In the form of "
+             "(begin, end, step), where begin is inclusive while end is "
+             "exclusive.")
+    args = parser.parse_args()
+    if args.weight_files is None and \
+            (args.weight_prefix is None or args.iter_range is None):
+        raise ValueError("Must provider either weight files or weight prefix "
+                         "and iter range.")
+    if args.iter_range is not None:
+        args.iter_range = eval('xrange' + args.iter_range)
+    main(args)


### PR DESCRIPTION
1. Adapt from this [official PR](https://github.com/BVLC/caffe/pull/4069) to support boost >= 1.60.
2. Fix bugs in `python/gen_bn_inference.py`. Add two options when a BN layer cannot be absorbed: freezing it, or replacing by a scale layer (with bias).
3. Add a script to convert inner product layers to convolution layers
4. Add a script to do polyak averaging
