### PR TITLE
Split MPI comm by specified groups

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -189,6 +189,12 @@ class Caffe {
   inline static int device_id(){return Get().device_id_;}
   inline static int remaining_sub_iter(){return Get().remaining_sub_iter_;}
   inline static void set_remaining_sub_iter(int n){Get().remaining_sub_iter_ = n;}
+
+  // Functions for splitting MPI_Comm to fast distributed training.
+  inline static void MPI_split_comm(const int color, const int key) {
+    MPI_Comm intra_comm;
+    MPI_Comm_split(MPI_COMM_WORLD, color, key, &intra_comm);
+  }
 #endif
 
 #ifdef WITH_PYTHON_LAYER

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -99,7 +99,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 38 (last added: richness)
+// SolverParameter next available ID: 39 (last added: group_id)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -184,6 +184,7 @@ message SolverParameter {
   optional SolverMode solver_mode = 17 [default = GPU];
   // the device_id will that be used in GPU mode. Use device_id = 0 in default.
   repeated int32 device_id = 18 ;
+  repeated int32 group_id = 38;
   // If non-negative, the seed with which the Solver will initialize the Caffe
   // random number generator -- useful for reproducible results. Otherwise,
   // (and by default) initialize using a seed derived from the system clock.


### PR DESCRIPTION
1. Add `group_id` in solver proto
2. Split mpi comm according to `group_id`

For example, to use 2 machines, you might need add following lines in solver.prototxt.

```
device_id: [0,1,2,3,0,1,2,3]
group_id: [0,0,0,0,1,1,1,1]
```
