### PR TITLE
Stochastic depth

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -180,6 +180,7 @@ class EltwiseLayer : public Layer<Dtype> {
   EltwiseParameter_EltwiseOp op_;
   vector<Dtype> coeffs_;
   Blob<int> max_idx_;
+  Blob<Dtype> rng_buffer_;
 
   bool stable_prod_grad_;
 };
@@ -783,7 +784,7 @@ class BNLayer : public Layer<Dtype> {
 };
 
 
-#if defined(USE_CUDNN) 
+#if defined(USE_CUDNN)
 #if CUDNN_VERSION_MIN(5, 0, 0)
 /**
  * @brief cuDNN implementation of BNLayer.

--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -26,6 +26,12 @@ void EltwiseLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     }
   }
   stable_prod_grad_ = this->layer_param_.eltwise_param().stable_prod_grad();
+  // Random number buffer for stochastic sum operation.
+  if (this->layer_param().eltwise_param().operation() ==
+      EltwiseParameter_EltwiseOp_STOCHASTIC_SUM) {
+    vector<int> shape(1, bottom.size());
+    rng_buffer_.Reshape(shape);
+  }
 }
 
 template <typename Dtype>
@@ -92,6 +98,22 @@ void EltwiseLayer<Dtype>::Forward_cpu(
       }
     }
     break;
+  case EltwiseParameter_EltwiseOp_STOCHASTIC_SUM:
+    caffe_set(count, Dtype(0), top_data);
+    if (this->phase_ == TRAIN) {
+      caffe_rng_uniform(bottom.size(), Dtype(0), Dtype(1),
+                        rng_buffer_.mutable_cpu_data());
+      for (int i = 0; i < bottom.size(); ++i) {
+        if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
+          caffe_axpy(count, Dtype(1), bottom[i]->cpu_data(), top_data);
+        }
+      }
+    } else {
+      for (int i = 0; i < bottom.size(); ++i) {
+        caffe_axpy(count, coeffs_[i], bottom[i]->cpu_data(), top_data);
+      }
+    }
+    break;
   default:
     LOG(FATAL) << "Unknown elementwise operation.";
   }
@@ -144,6 +166,18 @@ void EltwiseLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
           bottom_diff[index] = gradient;
         }
         break;
+      case EltwiseParameter_EltwiseOp_STOCHASTIC_SUM:
+        if (this->phase_ == TRAIN) {
+          if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
+            caffe_copy(count, top_diff, bottom_diff);
+          }
+        } else {
+          if (coeffs_[i] == Dtype(1)) {
+            caffe_copy(count, top_diff, bottom_diff);
+          } else {
+            caffe_cpu_scale(count, coeffs_[i], top_diff, bottom_diff);
+          }
+        }
       default:
         LOG(FATAL) << "Unknown elementwise operation.";
       }

--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -170,6 +170,8 @@ void EltwiseLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
         if (this->phase_ == TRAIN) {
           if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
             caffe_copy(count, top_diff, bottom_diff);
+          } else {
+            caffe_set(count, Dtype(0), bottom_diff);
           }
         } else {
           if (coeffs_[i] == Dtype(1)) {

--- a/src/caffe/layers/eltwise_layer.cu
+++ b/src/caffe/layers/eltwise_layer.cu
@@ -143,6 +143,8 @@ void EltwiseLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         if (this->phase_ == TRAIN) {
           if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
             caffe_copy(count, top_diff, bottom_diff);
+          } else {
+            caffe_gpu_set(count, Dtype(0), bottom_diff);
           }
         } else {
           if (coeffs_[i] == Dtype(1.)) {

--- a/src/caffe/layers/eltwise_layer.cu
+++ b/src/caffe/layers/eltwise_layer.cu
@@ -63,6 +63,22 @@ void EltwiseLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
           count, top_data, bottom[i]->gpu_data(), i-1, top_data, mask);
     }
     break;
+  case EltwiseParameter_EltwiseOp_STOCHASTIC_SUM:
+    caffe_gpu_set(count, Dtype(0.), top_data);
+    if (this->phase_ == TRAIN) {
+      caffe_rng_uniform(bottom.size(), Dtype(0), Dtype(1),
+                        rng_buffer_.mutable_cpu_data());
+      for (int i = 0; i < bottom.size(); ++i) {
+        if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
+          caffe_gpu_axpy(count, Dtype(1), bottom[i]->gpu_data(), top_data);
+        }
+      }
+    } else {
+      for (int i = 0; i < bottom.size(); ++i) {
+        caffe_gpu_axpy(count, coeffs_[i], bottom[i]->gpu_data(), top_data);
+      }
+    }
+    break;
   default:
     LOG(FATAL) << "Unknown elementwise operation.";
   }
@@ -122,6 +138,19 @@ void EltwiseLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         MaxBackward<Dtype>  // NOLINT_NEXT_LINE(whitespace/operators)
             <<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
             count, top_diff, i, mask, bottom_diff);
+        break;
+      case EltwiseParameter_EltwiseOp_STOCHASTIC_SUM:
+        if (this->phase_ == TRAIN) {
+          if (rng_buffer_.cpu_data()[i] <= coeffs_[i]) {
+            caffe_copy(count, top_diff, bottom_diff);
+          }
+        } else {
+          if (coeffs_[i] == Dtype(1.)) {
+            caffe_copy(count, top_diff, bottom_diff);
+          } else {
+            caffe_gpu_scale(count, coeffs_[i], top_diff, bottom_diff);
+          }
+        }
         break;
       default:
         LOG(FATAL) << "Unknown elementwise operation.";

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -571,6 +571,7 @@ message EltwiseParameter {
     PROD = 0;
     SUM = 1;
     MAX = 2;
+    STOCHASTIC_SUM = 3;
   }
   optional EltwiseOp operation = 1 [default = SUM]; // element-wise operation
   repeated float coeff = 2; // blob-wise coefficient for SUM operation


### PR DESCRIPTION
Add to `EltwiseLayer` a new `STOCHASTIC_SUM` operation, which randomly drops out bottom data during training. This operation can be used to implement the [stochastic depth ResNet](https://arxiv.org/abs/1603.09382). A typical layer configuration looks like

``` protobuf
layer {
  name: "eltwise"
  type: "Eltwise"
  bottom: "residual"
  bottom: "identity"
  top: "result"
  eltwise_param {
    operation: STOCHASTIC_SUM
    coeff: 0.75
    coeff: 1.0
  }
}
```

During training, it will keep the residual branch with probability of 0.75 (note that the entire bottom blob will be either discarded or kept, not each element individually). During test, the value of the residual branch will be multiplied by 0.75 before elementwisely added to the result.
