### PR TITLE
Synchronized BN layer

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -783,7 +783,7 @@ class BNLayer : public Layer<Dtype> {
 };
 
 
-#if defined(USE_CUDNN) 
+#if defined(USE_CUDNN)
 #if CUDNN_VERSION_MIN(5, 0, 0)
 /**
  * @brief cuDNN implementation of BNLayer.
@@ -820,6 +820,44 @@ class CuDNNBNLayer : public BNLayer<Dtype> {
   Blob<Dtype> save_inv_variance_;
 };
 #endif
+#endif
+
+#ifdef USE_MPI
+template <typename Dtype>
+class SyncBNLayer : public Layer<Dtype> {
+ public:
+  explicit SyncBNLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "SyncBN"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Dtype bn_momentum_;
+  Dtype bn_eps_;
+
+  int num_;
+  int channels_;
+  int height_;
+  int width_;
+
+  Blob<Dtype> mean_buffer_;
+  Blob<Dtype> var_buffer_;
+};
 #endif
 
 /**

--- a/src/caffe/layers/sync_bn_layer.cpp
+++ b/src/caffe/layers/sync_bn_layer.cpp
@@ -1,0 +1,88 @@
+#ifdef USE_MPI
+#include <algorithm>
+#include <vector>
+
+#include "caffe/common_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  bn_momentum_ = this->layer_param_.bn_param().momentum();
+  bn_eps_ = this->layer_param_.bn_param().eps();
+  // Initialize parameters
+  if (this->blobs_.size() > 0) {
+    LOG(INFO) << "Skipping parameter initialization";
+  } else {
+    this->blobs_.resize(4);
+    vector<int> shape;
+    shape.push_back(1);
+    shape.push_back(bottom[0]->channels());
+    // slope
+    this->blobs_[0].reset(new Blob<Dtype>(shape));
+    shared_ptr<Filler<Dtype> > slope_filler(GetFiller<Dtype>(
+        this->layer_param_.bn_param().slope_filler()));
+    slope_filler->Fill(this->blobs_[0].get());
+    // bias
+    this->blobs_[1].reset(new Blob<Dtype>(shape));
+    shared_ptr<Filler<Dtype> > bias_filler(GetFiller<Dtype>(
+        this->layer_param_.bn_param().bias_filler()));
+    bias_filler->Fill(this->blobs_[1].get());
+    // moving average mean
+    this->blobs_[2].reset(new Blob<Dtype>(shape));
+    caffe_set(this->blobs_[2]->count(), Dtype(0),
+        this->blobs_[2]->mutable_cpu_data());
+    // moving average variance
+    this->blobs_[3].reset(new Blob<Dtype>(shape));
+    caffe_set(this->blobs_[3]->count(), Dtype(0),
+        this->blobs_[3]->mutable_cpu_data());
+  }
+  this->param_propagate_down_.resize(this->blobs_.size(), true);
+
+  // runing average stats does not use weight decay and learning rate
+  while (this->layer_param_.param_size() < 4){
+    this->layer_param_.mutable_param()->Add();
+  }
+  this->layer_param_.mutable_param(2)->set_lr_mult(Dtype(0));
+  this->layer_param_.mutable_param(2)->set_decay_mult(Dtype(0));
+  this->layer_param_.mutable_param(3)->set_lr_mult(Dtype(0));
+  this->layer_param_.mutable_param(3)->set_decay_mult(Dtype(0));
+}
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  num_ = bottom[0]->num();
+  channels_ = bottom[0]->channels();
+  height_ = bottom[0]->height();
+  width_ = bottom[0]->width();
+
+  top[0]->ReshapeLike(*(bottom[0]));
+
+  mean_buffer_.Reshape(1, channels_, 1, 1);
+  var_buffer_.Reshape(1, channels_, 1, 1);
+}
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+}
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+}
+
+
+#ifdef CPU_ONLY
+STUB_GPU(SyncBNLayer);
+#endif
+
+INSTANTIATE_CLASS(SyncBNLayer);
+REGISTER_LAYER_CLASS(SyncBN);
+
+}  // namespace caffe
+
+#endif

--- a/src/caffe/layers/sync_bn_layer.cu
+++ b/src/caffe/layers/sync_bn_layer.cu
@@ -1,0 +1,231 @@
+#ifdef USE_MPI
+#include <algorithm>
+#include <vector>
+
+#include "caffe/common_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/mpi_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void kernel_test_forward(
+    const int num, const int channels, const int spatial_dim,
+    const Dtype* scale, const Dtype* bias, const Dtype* mean, const Dtype* var,
+    const Dtype eps, const Dtype* bottom_data, Dtype* top_data) {
+  CUDA_KERNEL_LOOP(index, num * channels * spatial_dim) {
+    int c = (index / spatial_dim) % channels;
+    top_data[index] = (bottom_data[index] - mean[c]) / sqrt(var[c] + eps)
+        * scale[c] + bias[c];
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_local_stats(int num, int channels, int spatial_dim,
+    const Dtype norm_factor,
+    const Dtype* bottom_data, Dtype* mean, Dtype* var) {
+  // store local E[x] to mean, E[x^2] to var temporarily
+  __shared__ Dtype buffer1[CAFFE_CUDA_NUM_THREADS];
+  __shared__ Dtype buffer2[CAFFE_CUDA_NUM_THREADS];
+  const int tid = threadIdx.x;
+  const int c = blockIdx.x;
+
+  // load and accumulate data on each thread
+  buffer1[tid] = buffer2[tid] = 0;
+  for (int i = tid; i < num * spatial_dim; i += blockDim.x) {
+    const int index = i / spatial_dim * channels * spatial_dim
+        + c * spatial_dim + i % spatial_dim;
+    buffer1[tid] += bottom_data[index];
+    buffer2[tid] += bottom_data[index] * bottom_data[index];
+  }
+  __syncthreads();
+
+  // do tree reduction
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      buffer1[tid] += buffer1[tid + s];
+      buffer2[tid] += buffer2[tid + s];
+    }
+    __syncthreads();
+  }
+
+  // save the result back
+  if (tid == 0) {
+    mean[c] = buffer1[0] / norm_factor;
+    var[c] = buffer2[0] / norm_factor;
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_backward_scale_bias(
+    const int num, const int channels, const int spatial_dim,
+    const Dtype* mean, const Dtype* var, const Dtype eps,
+    const Dtype* top_diff, const Dtype* bottom_data,
+    Dtype* scale_diff, Dtype* bias_diff) {
+  __shared__ Dtype buffer1[CAFFE_CUDA_NUM_THREADS];
+  __shared__ Dtype buffer2[CAFFE_CUDA_NUM_THREADS];
+  const int tid = threadIdx.x;
+  const int c = blockIdx.x;
+
+  // load and accumulate data on each thread
+  buffer1[tid] = buffer2[tid] = 0;
+  for (int i = tid; i < num * spatial_dim; i += blockDim.x) {
+    const int index = i / spatial_dim * channels * spatial_dim
+        + c * spatial_dim + i % spatial_dim;
+    buffer1[tid] += top_diff[index] * (bottom_data[index] - mean[c])
+                                    / sqrt(var[c] + eps);
+    buffer2[tid] += top_diff[index];
+  }
+  __syncthreads();
+
+  // do tree reduction
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      buffer1[tid] += buffer1[tid + s];
+      buffer2[tid] += buffer2[tid + s];
+    }
+    __syncthreads();
+  }
+
+  // save the result back
+  if (tid == 0) {
+    scale_diff[c] = buffer1[0];
+    bias_diff[c] = buffer2[0];
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_backward_bottom(
+    const int num, const int channels, const int spatial_dim,
+    const Dtype* scale, const Dtype* bias,
+    const Dtype* mean, const Dtype* var, const Dtype eps,
+    const Dtype norm_factor,
+    const Dtype* top_diff, const Dtype* scale_diff, const Dtype* bias_diff,
+    const Dtype* bottom_data, Dtype* bottom_diff) {
+  CUDA_KERNEL_LOOP(index, num * channels * spatial_dim) {
+    int c = (index / spatial_dim) % channels;
+    const Dtype inv_std = Dtype(1) / sqrt(var[c] + eps);
+    const Dtype x_norm = (bottom_data[index] - mean[c]) * inv_std;
+    bottom_diff[index] = scale[c] * inv_std *
+        (top_diff[index] - (x_norm * scale_diff[c] + bias_diff[c]) / norm_factor);
+  }
+}
+
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  if (this->phase_ == TEST) {
+    kernel_test_forward<<<CAFFE_GET_BLOCKS(bottom[0]->count()),
+        CAFFE_CUDA_NUM_THREADS>>>(
+      num_, channels_, height_ * width_,
+      this->blobs_[0]->gpu_data(),
+      this->blobs_[1]->gpu_data(),
+      this->blobs_[2]->gpu_data(),
+      this->blobs_[3]->gpu_data(),
+      bn_eps_,
+      bottom[0]->gpu_data(),
+      top[0]->mutable_gpu_data()
+    );
+    CUDA_POST_KERNEL_CHECK;
+  } else {
+    const int m = num_ * height_ * width_ * Caffe::MPI_all_rank();
+    // compute local E[x] and E[x^2]
+    kernel_local_stats<<<channels_, CAFFE_CUDA_NUM_THREADS>>>(
+      num_, channels_, height_ * width_,
+      static_cast<Dtype>(m),
+      bottom[0]->gpu_data(),
+      mean_buffer_.mutable_gpu_data(),
+      var_buffer_.mutable_gpu_data()
+    );
+    CUDA_POST_KERNEL_CHECK;
+    // sync E[x] and E[x^2]
+    mpi_force_synchronize();
+    caffe_iallreduce(mean_buffer_.mutable_cpu_data(), channels_);
+    caffe_iallreduce(var_buffer_.mutable_cpu_data(), channels_);
+    mpi_force_synchronize();
+    // var = (E[x^2] - E[x]^2) * bias_correction_factor
+    caffe_gpu_mul(channels_, mean_buffer_.gpu_data(), mean_buffer_.gpu_data(),
+                  top[0]->mutable_gpu_data());  // reuse the top buffer
+    caffe_gpu_sub(channels_, var_buffer_.gpu_data(), top[0]->gpu_data(),
+                  var_buffer_.mutable_gpu_data());
+    if (m > 1) {
+      caffe_gpu_scal(channels_, Dtype(m) / (m-1),
+                     var_buffer_.mutable_gpu_data());
+    }
+    // update running mean and var
+    caffe_gpu_axpby(mean_buffer_.count(),
+        Dtype(1) - bn_momentum_, mean_buffer_.gpu_data(),
+        bn_momentum_, this->blobs_[2]->mutable_gpu_data());
+    caffe_gpu_axpby(var_buffer_.count(),
+        Dtype(1) - bn_momentum_, var_buffer_.gpu_data(),
+        bn_momentum_, this->blobs_[3]->mutable_gpu_data());
+    // compute output
+    kernel_test_forward<<<CAFFE_GET_BLOCKS(bottom[0]->count()),
+        CAFFE_CUDA_NUM_THREADS>>>(
+      num_, channels_, height_ * width_,
+      this->blobs_[0]->gpu_data(),
+      this->blobs_[1]->gpu_data(),
+      mean_buffer_.gpu_data(),
+      var_buffer_.gpu_data(),
+      bn_eps_,
+      bottom[0]->gpu_data(),
+      top[0]->mutable_gpu_data()
+    );
+    CUDA_POST_KERNEL_CHECK;
+  }
+}
+
+template <typename Dtype>
+void SyncBNLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  if (propagate_down[0]) {
+    CHECK(this->param_propagate_down_[0] && this->param_propagate_down_[1])
+        << "SyncBN layer params should backprop when the layer backprops";
+    // compute local scale and bias diff
+    kernel_backward_scale_bias<<<channels_, CAFFE_CUDA_NUM_THREADS>>>(
+      num_, channels_, height_ * width_,
+      mean_buffer_.gpu_data(),
+      var_buffer_.gpu_data(),
+      bn_eps_,
+      top[0]->gpu_diff(),
+      bottom[0]->gpu_data(),
+      mean_buffer_.mutable_gpu_diff(),  // temp use for local scale diff
+      var_buffer_.mutable_gpu_diff() // temp use for local bias diff
+    );
+    CUDA_POST_KERNEL_CHECK;
+    // sync scale and bias diff
+    mpi_force_synchronize();
+    caffe_iallreduce(mean_buffer_.mutable_cpu_diff(), channels_);
+    caffe_iallreduce(var_buffer_.mutable_cpu_diff(), channels_);
+    mpi_force_synchronize();
+    // add to param blobs diff
+    caffe_gpu_axpy(channels_, Dtype(1) / Caffe::MPI_all_rank(),
+                   mean_buffer_.gpu_diff(),
+                   this->blobs_[0]->mutable_gpu_diff());
+    caffe_gpu_axpy(channels_, Dtype(1) / Caffe::MPI_all_rank(),
+                   var_buffer_.gpu_diff(),
+                   this->blobs_[1]->mutable_gpu_diff());
+    // compute bottom diff
+    kernel_backward_bottom<<<CAFFE_GET_BLOCKS(bottom[0]->count()),
+        CAFFE_CUDA_NUM_THREADS>>>(
+      num_, channels_, height_ * width_,
+      this->blobs_[0]->gpu_data(),
+      this->blobs_[1]->gpu_data(),
+      mean_buffer_.gpu_data(),
+      var_buffer_.gpu_data(),
+      bn_eps_,
+      static_cast<Dtype>(num_ * height_ * width_ * Caffe::MPI_all_rank()),
+      top[0]->gpu_diff(),
+      mean_buffer_.gpu_diff(),
+      var_buffer_.gpu_diff(),
+      bottom[0]->gpu_data(),
+      bottom[0]->mutable_gpu_diff()
+    );
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(SyncBNLayer);
+
+}  // namespace caffe
+#endif


### PR DESCRIPTION
This PR implements synchronized batch normalization layer (SyncBNLayer). It synchronizes the mean and variance across multiple GPUs during forward and backward. The statistics estimated are more stable, but the communication overhead could be quite significant.

To use it, just replace the layer type `BN` by `SyncBN` in prototxts. Note that currently only GPU implementations are available, and the `frozen` option is not supported.
