### PR TITLE
Fix a bug in recursively sharing data/diff

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -26,7 +26,7 @@ include(cmake/ProtoBuf.cmake)
 # ---[ HDF5
 find_package(HDF5 COMPONENTS HL REQUIRED)
 include_directories(SYSTEM ${HDF5_INCLUDE_DIRS} ${HDF5_HL_INCLUDE_DIR})
-list(APPEND Caffe_LINKER_LIBS ${HDF5_LIBRARIES})
+list(APPEND Caffe_LINKER_LIBS ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
 
 # ---[ LMDB
 find_package(LMDB REQUIRED)

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -272,6 +272,7 @@ class Net {
   bool debug_info_;
 
   /// Memory optimization related stuff.
+  bool optimize_memory_;
   vector< shared_ptr<SyncedMemory> > shared_storage_;
   std::set<string> excluded_blob_names_;
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -644,6 +644,13 @@ void Net<Dtype>::BackwardFromTo(int start, int end) {
   CHECK_LT(start, layers_.size());
 
   for (int i = start; i >= end; --i) {
+    const vector<Blob<Dtype>*>& bottom_vec = bottom_vecs_[i];
+    for (int j = 0; j < bottom_vec.size(); ++j)
+      if (!layer_need_backward_[i] || !bottom_need_backward_[i][j]) {
+        // Manually set the bottom diff to zero if it is not backpropagated.
+        // If not set, they may be corrupted when memory optimization is on.
+        bottom_vec[j]->scale_diff(0);
+      }
     if (layer_need_backward_[i]) {
 
       //DEBUG USE


### PR DESCRIPTION
There are cascaded data/diff sharing blobs. For example, blob `A -> A_split -> A_reshape`. In such case, the blob A is guaranteed to be assigned either an active slot, or an excluded slot (`index == -1`, for those I/O or user specified blobs). We just need to assign A_spit and A_shape with the same index as A.

Also we need to manually set bottom diff to zero if it is not backpropagated through. Otherwise it could be corrupted when memory optimization is on.
